### PR TITLE
Add special handling for first rule and default one for every other rule closes #24

### DIFF
--- a/paredros_debugger/CustomParser.py
+++ b/paredros_debugger/CustomParser.py
@@ -36,9 +36,13 @@ class CustomParser(Parser):
     def enterRule(self, localctx:ParserRuleContext, state:int, ruleIndex:int):
         rule_name = self.ruleNames[ruleIndex]
         if not self._errHandler.error_occurred:
-            # We can extract the state dirctly since the rule index is known
             state = self._interp.atn.ruleToStartState[ruleIndex]
-            self._errHandler.traversal._create_new_node("Rule entry", self, rule_name, None, state.stateNumber)
+            # The state for the first rule is always -1 so we have to add a special case to account for that
+            if self.state == -1: 
+                self._errHandler.traversal._create_new_node("Rule entry", self, rule_name, None, state.stateNumber)
+            # Every other rule has its normal statenumber and therefore doesnt need any special handling
+            else:
+                self._errHandler.traversal._create_new_node("Rule entry", self, rule_name, None)
         super().enterRule(localctx, state, ruleIndex)
 
     def exitRule(self):
@@ -51,7 +55,10 @@ class CustomParser(Parser):
         rule_name = self.ruleNames[ruleIndex]
         if not self._errHandler.error_occurred:
             state = self._interp.atn.ruleToStartState[ruleIndex]
-            self._errHandler.traversal._create_new_node("Rule entry", self, rule_name, None, state.stateNumber)
+            if self.state == -1: 
+                self._errHandler.traversal._create_new_node("Rule entry", self, rule_name, None, state.stateNumber)
+            else:
+                self._errHandler.traversal._create_new_node("Rule entry", self, rule_name, None)
         super().enterRecursionRule(localctx, state, ruleIndex, precedence)
 
     def match(self, ttype):


### PR DESCRIPTION
Change im Aufruf von `_create_new_node` für Ruleentries sodass nur noch der gegebene State an die Methode geliefert wird, wenn es sich bei der Rule um die Startrule handelt. Diese hat intern noch keinen State und braucht deshalb ein eigenes Handling. Für die anderen Ruleentries wurde wieder die alte Logik verwendet, sodass es im Parsetree nicht mehr zu `chosen_transition_index` = -1 kommt. Das müsste auch den Fehler in der Paredros-App beheben.